### PR TITLE
support options and locals separately

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,13 @@
 'use strict';
 
 var qejs = require('qejs');
+var extend = require('extend-shallow');
 
 exports.name = 'qejs';
+exports.inputFormats = ['html', 'ejs', 'qejs'];
 exports.outputFormat = 'html';
 
-exports.renderAsync = qejs.render;
+exports.renderAsync = function _renderAsync(str, options, locals) {
+  var o = extend({}, options, locals);
+  return qejs.render(str, o);
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "author": "Rob Loach <robloach@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "extend-shallow": "^1.1.2",
     "qejs": "^3.0.5"
   }
 }

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -1,1 +1,1 @@
-Countries: Canada, United States, China, Columbia
+Hello world! Countries: Canada, United States, China, Columbia

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,11 @@ function assertEqual(output, expected) {
 
 test('QEJS', function (done) {
   var options = {
+    open: '{%',
+    close: '%}',
+    place: 'world'
+  };
+  var locals = {
     'countries': [
       'Canada',
       'United States',
@@ -25,8 +30,8 @@ test('QEJS', function (done) {
       'Columbia'
     ]
   };
-  transform.renderAsync(input, options).then(function (out) {
+  transform.renderAsync(input, options, locals).then(function (out) {
     assertEqual(out.trim(), expected.trim());
     done();
-  }); 
+  });
 });

--- a/test/input.txt
+++ b/test/input.txt
@@ -1,1 +1,1 @@
-Countries: <% countries -> countries %><%= countries.join(', ') %><% <- %>
+Hello {%= place %}! Countries: {% countries -> countries %}{%= countries.join(', ') %}{% <- %}


### PR DESCRIPTION
because people would expect to set options as second argument and locals as 3rd. there may have some use case in the wild for doing this.

yea its not a problem for them to go to `qejs` and see that `qejs` only support one object which is `options` and `locals` in same time but.. let follow our signature.
