### PR TITLE
fix(inputFormats): Remove html from the inputFormats

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var qejs = require('qejs');
 var extend = require('extend-shallow');
 
 exports.name = 'qejs';
-exports.inputFormats = ['html', 'ejs', 'qejs'];
+exports.inputFormats = ['ejs', 'qejs'];
 exports.outputFormat = 'html';
 
 exports.renderAsync = function _renderAsync(str, options, locals) {


### PR DESCRIPTION
@tunnckoCore The way to think of inputFormats is "what should I use as the file extension for the input". You wouldn't input straight HTML into QEJS, so let's remove `html` from here.
